### PR TITLE
refactor: improve performance of invalidation

### DIFF
--- a/src/http_cache_store_memory.erl
+++ b/src/http_cache_store_memory.erl
@@ -36,7 +36,9 @@ get_response(ObjectKey, _Opts) ->
             undefined
     end.
 
-put(RequestKey, UrlDigest, VaryHeaders, Response, #{grace := _} = RespMetadata, _Opts) ->
+put(RequestKey, UrlDigest, VaryHeaders, Response, #{grace := _} = RespMetadata0, _Opts) ->
+    AlternateKeys = maps:get(alternate_keys, RespMetadata0, []),
+    RespMetadata = maps:put(alternate_keys, maps:from_keys(AlternateKeys, []), RespMetadata0),
     case http_cache_store_memory_worker_sup:start_worker({cache_object,
                                                           {RequestKey,
                                                            UrlDigest,

--- a/src/http_cache_store_memory_worker.erl
+++ b/src/http_cache_store_memory_worker.erl
@@ -36,18 +36,12 @@ cache_object({RequestKey, UrlDigest, VaryHeaders, Response, RespMetadata}) ->
     http_cache_store_memory:lru(ObjectKey, SeqNumber).
 
 invalidate_url(UrlDigest) ->
-    invalidate_url(UrlDigest, ets:first(?OBJECT_TABLE)).
-
-invalidate_url(_UrlDigest, '$end_of_table') ->
-    ok;
-invalidate_url(UrlDigest, ObjectKey) ->
-    case ets:lookup(?OBJECT_TABLE, ObjectKey) of
-        [{_, _, UrlDigest, _, _, _}] ->
-            http_cache_store_memory:delete_object(ObjectKey, url_invalidation),
-            invalidate_url(UrlDigest, ets:next(?OBJECT_TABLE, ObjectKey));
-        _ ->
-            invalidate_url(UrlDigest, ets:next(?OBJECT_TABLE, ObjectKey))
-    end.
+    MatchSpec = [{{'_', '_', '$1', '_', '_', '_'}, [{'==', UrlDigest, '$1'}], [true]}],
+    NbDeleted = ets:select_delete(?OBJECT_TABLE, MatchSpec),
+    [telemetry:execute([http_cache_store_memory, object_deleted],
+                       #{},
+                       #{reason => url_invalidation})
+     || _ <- lists:seq(0, NbDeleted - 1)].
 
 invalidate_by_alternate_key(AltKeys) ->
     MatchSpec =

--- a/src/http_cache_store_memory_worker.erl
+++ b/src/http_cache_store_memory_worker.erl
@@ -50,23 +50,16 @@ invalidate_url(UrlDigest, ObjectKey) ->
     end.
 
 invalidate_by_alternate_key(AltKeys) ->
-    invalidate_by_alternate_key(AltKeys, ets:first(?OBJECT_TABLE)).
-
-invalidate_by_alternate_key(_AltKeys, '$end_of_table') ->
-    ok;
-invalidate_by_alternate_key(AltKeys, ObjectKey) ->
-    case ets:lookup(?OBJECT_TABLE, ObjectKey) of
-        [{_, _, _, _, #{alternate_keys := ObjectAltKeys}, _}] ->
-            case lists:any(fun(AltKey) -> lists:member(AltKey, ObjectAltKeys) end, AltKeys) of
-                true ->
-                    http_cache_store_memory:delete_object(ObjectKey, alternate_key_invalidation),
-                    invalidate_by_alternate_key(AltKeys, ets:next(?OBJECT_TABLE, ObjectKey));
-                false ->
-                    invalidate_by_alternate_key(AltKeys, ets:next(?OBJECT_TABLE, ObjectKey))
-            end;
-        _ ->
-            invalidate_by_alternate_key(AltKeys, ets:next(?OBJECT_TABLE, ObjectKey))
-    end.
+    MatchSpec =
+        [{{'_', '_', '_', '_', #{alternate_keys => '$1'}, '_'},
+          [{is_map_key, AltKey, '$1'}],
+          [true]}
+         || AltKey <- AltKeys],
+    NbDeleted = ets:select_delete(?OBJECT_TABLE, MatchSpec),
+    [telemetry:execute([http_cache_store_memory, object_deleted],
+                       #{},
+                       #{reason => alternate_key_invalidation})
+     || _ <- lists:seq(0, NbDeleted - 1)].
 
 warmup_node(Node, NbObjects) ->
     warmup_node(Node, ets:last(?LRU_TABLE), NbObjects).

--- a/test/base_SUITE.erl
+++ b/test/base_SUITE.erl
@@ -75,8 +75,6 @@ invalidate_by_url(_Config) ->
                                 ?TEST_RESP_METADATA,
                                 ?TEST_OPTS),
     http_cache_store_memory:invalidate_url(?TEST_URL_DIGEST, ?TEST_OPTS),
-    timer:sleep(1000),
-    [] = http_cache_store_memory:list_candidates(?TEST_REQUEST_KEY, ?TEST_OPTS),
     receive
         {[http_cache_store_memory, object_deleted],
          TelemetryRef,
@@ -85,7 +83,8 @@ invalidate_by_url(_Config) ->
             telemetry:detach(TelemetryRef)
     after 1000 ->
         ct:fail(timeout_receive_telemetry_event)
-    end.
+    end,
+    [] = http_cache_store_memory:list_candidates(?TEST_REQUEST_KEY, ?TEST_OPTS).
 
 invalidate_by_alternate_key(_Config) ->
     TelemetryRef =
@@ -97,8 +96,6 @@ invalidate_by_alternate_key(_Config) ->
                                 ?TEST_RESP_METADATA,
                                 ?TEST_OPTS),
     http_cache_store_memory:invalidate_by_alternate_key([alternate], ?TEST_OPTS),
-    timer:sleep(1000),
-    [] = http_cache_store_memory:list_candidates(?TEST_REQUEST_KEY, ?TEST_OPTS),
     receive
         {[http_cache_store_memory, object_deleted],
          TelemetryRef,
@@ -107,7 +104,8 @@ invalidate_by_alternate_key(_Config) ->
             telemetry:detach(TelemetryRef)
     after 1000 ->
         ct:fail(timeout_receive_telemetry_event)
-    end.
+    end,
+    [] = http_cache_store_memory:list_candidates(?TEST_REQUEST_KEY, ?TEST_OPTS).
 
 cache_chunks(_Config) ->
     ChunkMetadata1 =


### PR DESCRIPTION
In this PR, we
- transform the alternate key list into a map for better performance when invalidating (we no longer need to traverse the list)
- use `ets:select_delete/2` to invalidate by URL or by alternate key, hoping we gain performance